### PR TITLE
Extract basic ball and camera sim wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Codex Agent Instructions
+
+This repository aims to build **libmkb**, a standalone C/C++ library that can simulate the physics, camera, and control logic of **Super Monkey Ball 2**. These are the guiding principles for all future contributions:
+
+## Goals
+- **Readability**: produce clear, well-documented code that faithfully reflects the original game's logic so that it can be easily understood.
+- **Accuracy**: the resulting library should behave identically to the original game aside from unavoidable floating-point rounding differences.
+- **Embeddability**: the core logic should compile as a reusable C++ library for use in custom frontends, including a WebAssembly build for browser-based frontends.
+
+## Lower Priorities
+- **Perfect matching** of the original binary is not required if it harms readability or embeddability.
+- **Full completeness** (e.g. menus, graphics, character animation) is secondary to physics, camera, and controls.
+
+Codex agents should follow these principles when decompiling, refactoring, or adding functionality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
 # Codex Agent Instructions
 
-This repository aims to build **libmkb**, a standalone C/C++ library that can simulate the physics, camera, and control logic of **Super Monkey Ball 2**. These are the guiding principles for all future contributions:
+This repository aims to build **libmkb**, a standalone C/C++ library that can simulate the physics, camera, and control logic of **Super Monkey Ball**. These are the guiding principles for all future contributions:
 
 ## Goals
 - **Readability**: produce clear, well-documented code that faithfully reflects the original game's logic so that it can be easily understood.
 - **Accuracy**: the resulting library should behave identically to the original game aside from unavoidable floating-point rounding differences.
-- **Embeddability**: the core logic should compile as a reusable C++ library for use in custom frontends, including a WebAssembly build for browser-based frontends.
+- **Embeddability**: the core logic should compile as a reusable C++ library for use in custom frontends. Compiling libmkb for the browser via WebAssembly with three.js for graphics is the endgoal for an initial frontend.
 
-## Lower Priorities
+## Non-Goals
 - **Perfect matching** of the original binary is not required if it harms readability or embeddability.
-- **Full completeness** (e.g. menus, graphics, character animation) is secondary to physics, camera, and controls.
+- **Full completeness** (e.g. menus, graphics, character animation) is not a concern. Focus on physics, camera, and controls.
 
 Codex agents should follow these principles when decompiling, refactoring, or adding functionality.

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,11 @@ SOURCES := \
 	src/mot_joint.c \
 	src/motload_3.c \
 	src/motload_4.c \
-	src/ball.c \
-	src/stcoli.c \
+       src/ball.c \
+       src/lib/ball_sim.c \
+       src/lib/camera_sim.c \
+       src/lib/stage_loader.c \
+       src/stcoli.c \
 	src/world.c \
 	src/interpolate_keyframes.c \
 	src/stage.c \

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 DOL_LDFLAGS := -nodefaults -fp hard
 REL_LDFLAGS := -nodefaults -fp hard -r1 -m _prolog -g
 
-HOSTCFLAGS   := -Wall -O3 -s
+HOSTCFLAGS   := -Wall -O3 -s -DLIBMKB_HOST
 
 CC_CHECK     := $(GCC) $(GCC_CFLAGS) -fsyntax-only $(GCC_CPPFLAGS)
 
@@ -581,14 +581,15 @@ clean:
 	find . -name '*.dep' -exec rm {} +
 	find . -name '*.dump' -exec rm {} +
 
-LIBMKB_SRCS := src/lib/stage_loader.c src/lib/ball_sim.c src/lib/camera_sim.c
+LIBMKB_SRCS := src/lib/stage_loader.c src/lib/ball_sim.c src/lib/camera_sim.c \
+               src/lib/host_load.c src/lib/host_os.c
 LIBMKB_OBJS := $(LIBMKB_SRCS:.c=.lib.o)
 
 libmkb.a: $(LIBMKB_OBJS)
 	$(AR) rcs $@ $^
 
 %.lib.o: %.c
-	$(HOSTCC) $(HOSTCFLAGS) -Isrc -Iinclude -c $< -o $@
+	$(HOSTCC) $(HOSTCFLAGS) -I/usr/include -Isrc -Iinclude -c $< -o $@
 
 .PHONY: libmkb
 libmkb: libmkb.a

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ SHA1SUM := sha1sum
 ELF2DOL := tools/elf2dol$(EXE)
 ELF2REL := tools/elf2rel$(EXE)
 LZSS    := tools/lzss$(EXE)
+AR      := ar
 
 # Game include directories
 INCLUDE_DIRS := src data
@@ -509,7 +510,7 @@ ALL_RELS += mkbe.option.rel
 .SUFFIXES:
 MAKEFLAGS += -r
 
-all: $(DOL) $(ALL_RELS)
+all: $(DOL) $(ALL_RELS) libmkb.a
 	$(QUIET) $(SHA1SUM) -c supermonkeyball.sha1
 
 # static module (.dol file)
@@ -575,10 +576,22 @@ src/unk_anim_data.c.o: src/unk_anim_data.c
 	$(OBJDUMP) -Drz $< > $@
 
 clean:
-	$(RM) $(DOL) $(ELF) $(MAP) $(ALL_RELS) $(ELF2DOL) $(ELF2REL)
+	$(RM) $(DOL) $(ELF) $(MAP) $(ALL_RELS) libmkb.a $(ELF2DOL) $(ELF2REL)
 	find . -name '*.o' -exec rm {} +
 	find . -name '*.dep' -exec rm {} +
 	find . -name '*.dump' -exec rm {} +
+
+LIBMKB_SRCS := src/lib/stage_loader.c src/lib/ball_sim.c src/lib/camera_sim.c
+LIBMKB_OBJS := $(LIBMKB_SRCS:.c=.lib.o)
+
+libmkb.a: $(LIBMKB_OBJS)
+	$(AR) rcs $@ $^
+
+%.lib.o: %.c
+	$(HOSTCC) $(HOSTCFLAGS) -Isrc -Iinclude -c $< -o $@
+
+.PHONY: libmkb
+libmkb: libmkb.a
 
 #-------------------------------------------------------------------------------
 # Test Recipes

--- a/README.md
+++ b/README.md
@@ -24,3 +24,31 @@ supermonkeyball.dol: `sha1: 424e8ce10135686de0709a147e6a3a5a3fda02f1`
   - mwldeppc.exe
   - lmgr326b.dll
 * Run `make` from the repository root directory. If you are using a version of CodeWarrior besides 1.1, you must run `make COMPILER_VERSION=<VERSION>` (where `<VERSION>` is your CodeWarrior version).
+
+### Building libmkb
+
+Running `make libmkb.a` will compile the standalone simulation library `libmkb.a` using the host compiler. This library contains the stage loading, ball, and camera simulation code and can be linked into custom frontends.
+
+Example usage:
+
+```c
+#include <libmkb.h>
+
+int main(void) {
+    struct Ball ball;
+    struct Camera camera;
+
+    load_stage_collision(1);       // Load STAGE001
+    ball_sim_init(&ball);
+    camera_sim_init(&camera, &ball);
+
+    while (1) {
+        ball_sim_step(&ball);
+        camera_sim_step(&camera, &ball);
+        // render here
+    }
+
+    free_stage_collision();
+    return 0;
+}
+```

--- a/include/ball_sim.h
+++ b/include/ball_sim.h
@@ -1,6 +1,7 @@
 #ifndef BALL_SIM_H
 #define BALL_SIM_H
 
+#include "global.h"
 #include "ball.h"
 
 void ball_sim_init(struct Ball *ball);

--- a/include/ball_sim.h
+++ b/include/ball_sim.h
@@ -1,0 +1,9 @@
+#ifndef BALL_SIM_H
+#define BALL_SIM_H
+
+#include "ball.h"
+
+void ball_sim_init(struct Ball *ball);
+void ball_sim_step(struct Ball *ball);
+
+#endif // BALL_SIM_H

--- a/include/ball_sim.h
+++ b/include/ball_sim.h
@@ -4,7 +4,15 @@
 #include "global.h"
 #include "ball.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ball_sim_init(struct Ball *ball);
 void ball_sim_step(struct Ball *ball);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // BALL_SIM_H

--- a/include/camera_sim.h
+++ b/include/camera_sim.h
@@ -1,7 +1,9 @@
 #ifndef CAMERA_SIM_H
 #define CAMERA_SIM_H
 
+#include "global.h"
 #include "camera.h"
+#include "ball.h"
 
 void camera_sim_init(struct Camera *camera, struct Ball *ball);
 void camera_sim_step(struct Camera *camera, struct Ball *ball);

--- a/include/camera_sim.h
+++ b/include/camera_sim.h
@@ -1,0 +1,9 @@
+#ifndef CAMERA_SIM_H
+#define CAMERA_SIM_H
+
+#include "camera.h"
+
+void camera_sim_init(struct Camera *camera, struct Ball *ball);
+void camera_sim_step(struct Camera *camera, struct Ball *ball);
+
+#endif // CAMERA_SIM_H

--- a/include/camera_sim.h
+++ b/include/camera_sim.h
@@ -5,7 +5,15 @@
 #include "camera.h"
 #include "ball.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void camera_sim_init(struct Camera *camera, struct Ball *ball);
 void camera_sim_step(struct Camera *camera, struct Ball *ball);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // CAMERA_SIM_H

--- a/include/dolphin.h
+++ b/include/dolphin.h
@@ -1,23 +1,23 @@
 #ifndef _DOLPHIN_H_
 #define _DOLPHIN_H_
 
-#include <dolphin/types.h>
-#include <dolphin/os.h>
-#include <dolphin/dsp.h>
-#include <dolphin/dvd.h>
-#include <dolphin/gx.h>
-#include <dolphin/hio.h>
-#include <dolphin/mtx.h>
-#include <dolphin/vi.h>
-#include <dolphin/card.h>
-#include <dolphin/perf.h>
-#include <dolphin/ar.h>
-#include <dolphin/arq.h>
-#include <dolphin/base/PPCArch.h>
-#include <dolphin/DBInterface.h>
-#include <dolphin/DEMOPuts.h>
-#include <dolphin/pad.h>
-#include <dolphin/dtk.h>
+#include "dolphin/types.h"
+#include "dolphin/os.h"
+#include "dolphin/dsp.h"
+#include "dolphin/dvd.h"
+#include "dolphin/gx.h"
+#include "dolphin/hio.h"
+#include "dolphin/mtx.h"
+#include "dolphin/vi.h"
+#include "dolphin/card.h"
+#include "dolphin/perf.h"
+#include "dolphin/ar.h"
+#include "dolphin/arq.h"
+#include "dolphin/base/PPCArch.h"
+#include "dolphin/DBInterface.h"
+#include "dolphin/DEMOPuts.h"
+#include "dolphin/pad.h"
+#include "dolphin/dtk.h"
 #include <dolphin/ai.h>
 
 #endif

--- a/include/dolphin/os.h
+++ b/include/dolphin/os.h
@@ -1,17 +1,17 @@
 #ifndef _DOLPHIN_OS_H_
 #define _DOLPHIN_OS_H_
 
-#include <dolphin/OSAlloc.h>
-#include <dolphin/OSCache.h>
-#include <dolphin/OSContext.h>
-#include <dolphin/OSInterrupt.h>
-#include <dolphin/OSModule.h>
-#include <dolphin/OSThread.h>
-#include <dolphin/OSMutex.h>
-#include <dolphin/OSFont.h>
-#include <dolphin/OSReset.h>
-#include <dolphin/OSResetSW.h>
-#include <dolphin/OSError.h>
+#include "dolphin/OSAlloc.h"
+#include "dolphin/OSCache.h"
+#include "dolphin/OSContext.h"
+#include "dolphin/OSInterrupt.h"
+#include "dolphin/OSModule.h"
+#include "dolphin/OSThread.h"
+#include "dolphin/OSMutex.h"
+#include "dolphin/OSFont.h"
+#include "dolphin/OSReset.h"
+#include "dolphin/OSResetSW.h"
+#include "dolphin/OSError.h"
 
 // private macro, maybe shouldn't be defined here?
 #define OFFSET(addr, align) (((u32)(addr) & ((align)-1)))

--- a/include/libmkb.h
+++ b/include/libmkb.h
@@ -1,0 +1,25 @@
+#ifndef LIBMKB_H
+#define LIBMKB_H
+
+#include "stage.h"
+#include "ball.h"
+#include "camera.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void load_stage_collision(int stageId);
+void free_stage_collision(void);
+
+void ball_sim_init(struct Ball *ball);
+void ball_sim_step(struct Ball *ball);
+
+void camera_sim_init(struct Camera *camera, struct Ball *ball);
+void camera_sim_step(struct Camera *camera, struct Ball *ball);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LIBMKB_H

--- a/include/ppcintrinsic.h
+++ b/include/ppcintrinsic.h
@@ -4,7 +4,11 @@
 // Implement MetroWerks PowerPC intrinsics for other compilers
 
 #ifndef __MWERKS__
-#include <math.h>
+#ifdef __GNUC__
+# include_next <math.h>
+#else
+# include <math.h>
+#endif
 
 static inline unsigned int __cntlzw(unsigned int n)
 {

--- a/include/ppcintrinsic.h
+++ b/include/ppcintrinsic.h
@@ -4,25 +4,33 @@
 // Implement MetroWerks PowerPC intrinsics for other compilers
 
 #ifndef __MWERKS__
+#include <math.h>
+
 static inline unsigned int __cntlzw(unsigned int n)
 {
-    unsigned int ret;
-    asm("cntlzw %0, %1" : "=r"(ret) : "r"(n));
-    return ret;
+#ifdef __GNUC__
+    return n ? __builtin_clz(n) : 32;
+#else
+    unsigned int count = 0;
+    while ((n & 0x80000000u) == 0 && count < 32)
+    {
+        n <<= 1;
+        count++;
+    }
+    return count;
+#endif
 }
 
 static inline unsigned int __lwbrx(void *ptr, unsigned int offset)
 {
-    unsigned int ret;
-    asm("lwbrx %0, %1, %2" : "=r"(ret) : "r"(ptr), "r"(offset));
-    return ret;
+    unsigned char *p = (unsigned char *)ptr + offset;
+    return (unsigned int)p[0] << 24 | (unsigned int)p[1] << 16 |
+           (unsigned int)p[2] << 8 | p[3];
 }
 
 static inline float __frsqrte(float n)
 {
-    float ret;
-    asm("frsqrte %0, %1" : "=f"(ret) : "f"(n));
-    return ret;
+    return 1.0f / sqrtf(n);
 }
 #endif
 

--- a/include/stage_loader.h
+++ b/include/stage_loader.h
@@ -1,0 +1,11 @@
+#ifndef STAGE_LOADER_H
+#define STAGE_LOADER_H
+
+#include "stage.h"
+
+extern struct Stage *decodedStageLzPtr;
+
+void load_stage_collision(int stageId);
+void free_stage_collision(void);
+
+#endif // STAGE_LOADER_H

--- a/include/stddef.h
+++ b/include/stddef.h
@@ -3,7 +3,11 @@
 
 #define offsetof(type, member)	((size_t) &(((type *) 0)->member))
 
+#ifdef LIBMKB_HOST
+typedef unsigned long size_t;
+#else
 typedef unsigned int size_t;
+#endif
 
 #define NULL 0L
 

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -30,5 +30,8 @@ int printf(const char *, ...);
 int sprintf(char *s, const char *format, ...);
 int vprintf(const char *format, va_list arg);
 int vsprintf(char *s, const char *format, va_list arg);
+int fprintf(FILE *stream, const char *format, ...);
+int vfprintf(FILE *stream, const char *format, va_list arg);
+extern FILE *stderr;
 
 #endif

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -10,6 +10,9 @@ void srand(unsigned int seed);
 int rand(void);
 void exit(int status);
 size_t wcstombs(char *dest, const wchar_t *src, size_t max);
+void *malloc(size_t size);
+void free(void *ptr);
+void abort(void);
 
 #ifdef __MWERKS__
 #define abs(x) __abs(x)

--- a/src/functions.h
+++ b/src/functions.h
@@ -2,6 +2,7 @@
 #define _SRC_FUNCTIONS_H_
 
 #include "types.h"
+#include <dolphin/dvd.h>
 
 // ? main();
 void initialize(void);

--- a/src/lib/ball_sim.c
+++ b/src/lib/ball_sim.c
@@ -1,0 +1,70 @@
+#include "ball_sim.h"
+#include "ball.h"
+#include "world.h"
+
+// Local copy of the state dispatch table used by the main game
+static void (*const ball_sim_funcs[])(struct Ball *) = {
+    ball_func_0,              // BALL_STATE_0
+    ball_func_1,              // BALL_STATE_1
+    ball_func_ready_main,     // BALL_STATE_READY_MAIN
+    ball_func_3,              // BALL_STATE_3
+    ball_func_4,              // BALL_STATE_4
+    ball_func_goal_init,      // BALL_STATE_GOAL_INIT
+    ball_func_goal_main,      // BALL_STATE_GOAL_MAIN
+    ball_func_replay_init,    // BALL_STATE_REPLAY_INIT_1
+    ball_func_replay_main,    // BALL_STATE_REPLAY_MAIN_1
+    ball_func_replay_init,    // BALL_STATE_REPLAY_INIT_2
+    ball_func_replay_main,    // BALL_STATE_REPLAY_MAIN_2
+    ball_func_11,
+    ball_func_12,
+    ball_func_13,
+    ball_func_14,
+    ball_func_15,
+    ball_func_16,
+    ball_func_17,
+    ball_func_18,
+    ball_func_19,
+    ball_func_20,
+    ball_func_demo_init,
+    ball_func_mini,
+    ball_func_mini,
+    ball_func_mini,
+    ball_func_mini,
+    ball_func_mini,
+    ball_func_27,
+    ball_func_28,
+};
+
+static void clear_some_ball_flags_inline(struct Ball *ball)
+{
+    ball->flags &= ~(BALL_FLAG_27|BALL_FLAG_28|BALL_FLAG_29|BALL_FLAG_30|BALL_FLAG_31);
+}
+
+// Initialize ball for main gamemode
+void ball_sim_init(struct Ball *ball)
+{
+    // Use existing initialization routines
+    // Equivalent to calling ball_func_ready_main after basic setup
+    ball_func_1(ball);
+}
+
+// Step ball simulation for one frame in the main gamemode
+void ball_sim_step(struct Ball *ball)
+{
+    // The normal event loop updates all balls in ev_ball_main.
+    // Here we simulate only a single ball for external library use.
+    currentBall = ball;
+    ball->unk120 = ball->flags;
+    ball->flags &= ~(BALL_FLAG_00|BALL_FLAG_02);
+    clear_some_ball_flags_inline(ball);
+    set_ball_look_point(4, &ball->pos, 0.75f);
+    ball_sim_funcs[ball->state](ball);
+    func_80038528(ball);
+    ball->u_opacity[0] = ball->u_opacity[1] = ball->u_opacity[2] = ball->u_opacity[3] = 1.0f;
+    ball_ape_yang(ball);
+    ball_effect();
+    animate_ball_size_change(ball);
+    ball_sound(ball);
+    if (ball->unk14E > 0)
+        ball->unk14E--;
+}

--- a/src/lib/camera_sim.c
+++ b/src/lib/camera_sim.c
@@ -1,5 +1,6 @@
 #include "camera_sim.h"
-#include "camera.h"
+
+extern void (*cameraFuncs[])(struct Camera *, struct Ball *);
 
 void camera_sim_init(struct Camera *camera, struct Ball *ball)
 {

--- a/src/lib/camera_sim.c
+++ b/src/lib/camera_sim.c
@@ -1,0 +1,17 @@
+#include "camera_sim.h"
+#include "camera.h"
+
+void camera_sim_init(struct Camera *camera, struct Ball *ball)
+{
+    // Set up camera using existing initialization logic
+    camera_init();
+    ev_camera_init();
+    camera->state = CAMERA_STATE_READY_INIT;
+    cameraFuncs[camera->state](camera, ball);
+}
+
+void camera_sim_step(struct Camera *camera, struct Ball *ball)
+{
+    currentCamera = camera;
+    cameraFuncs[camera->state](camera, ball);
+}

--- a/src/lib/host_load.c
+++ b/src/lib/host_load.c
@@ -1,0 +1,51 @@
+#ifdef LIBMKB_HOST
+#include "load.h"
+#include <stddef.h>
+
+typedef struct _FILE FILE;
+FILE *fopen(const char *, const char *);
+int fclose(FILE *);
+int fseek(FILE *, long, int);
+long ftell(FILE *);
+size_t fread(void *, size_t, size_t, FILE *);
+
+#define SEEK_SET 0
+#define SEEK_END 2
+
+BOOL file_open(const char *filename, struct File *file)
+{
+    FILE *fp = fopen(filename, "rb");
+    if (!fp)
+        return FALSE;
+    file->isCached = FALSE;
+    file->dvdFile.cb.userData = fp;
+    fseek(fp, 0, SEEK_END);
+    file->dvdFile.length = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    return TRUE;
+}
+
+BOOL file_close(struct File *file)
+{
+    FILE *fp = (FILE *)file->dvdFile.cb.userData;
+    if (!fp)
+        return FALSE;
+    fclose(fp);
+    file->dvdFile.cb.userData = NULL;
+    return TRUE;
+}
+
+s32 file_read(struct File *file, void *dest, u32 size, u32 offset)
+{
+    FILE *fp = (FILE *)file->dvdFile.cb.userData;
+    if (!fp)
+        return -1;
+    fseek(fp, offset, SEEK_SET);
+    return fread(dest, 1, size, fp);
+}
+
+u32 file_size(struct File *file)
+{
+    return file->dvdFile.length;
+}
+#endif

--- a/src/lib/host_os.c
+++ b/src/lib/host_os.c
@@ -1,0 +1,25 @@
+#ifdef LIBMKB_HOST
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "dolphin/os.h"
+
+void OSReport(char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    vprintf(msg, args);
+    va_end(args);
+}
+
+void OSPanic(char *file, int line, char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    fprintf(stderr, "PANIC: %s:%d: ", file, line);
+    vfprintf(stderr, msg, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+    abort();
+}
+#endif

--- a/src/lib/stage_loader.c
+++ b/src/lib/stage_loader.c
@@ -1,0 +1,266 @@
+#include <dolphin.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "global.h"
+#include "load.h"
+#include "stage_loader.h"
+#include "functions.h"
+
+u8 lbl_8020AE00[0x20] __attribute__((aligned(32)));
+FORCE_BSS_ORDER(lbl_8020AE00)
+
+struct Stage *decodedStageLzPtr;
+
+#undef OFFSET_TO_PTR
+#define OFFSET_TO_PTR(base, offset) (void *)((u32)(offset) + (u32)(base))
+
+void load_stage_collision(int stageId)
+{
+    struct File file;
+    char filename[32];
+    u8 unused[8];
+    u32 compSize;
+    u32 uncompSize;
+    void *compData;
+    void *uncompData;
+    struct StageAnimGroup *coll;
+    int i;
+
+    sprintf(filename, "STAGE%03d.lz", stageId);
+
+    if (!file_open(filename, &file))
+        OSPanic("stage_loader.c", __LINE__, "cannot Open");
+
+    if (file_read(&file, lbl_8020AE00, 32, 0) < 0)
+        OSPanic("stage_loader.c", __LINE__, "cannot Read");
+    compSize = OSRoundUp32B(__lwbrx(lbl_8020AE00, 0));
+    uncompSize = OSRoundUp32B(__lwbrx(lbl_8020AE00, 4));
+
+    uncompData = malloc(uncompSize);
+    if (uncompData == NULL)
+        OSPanic("stage_loader.c", __LINE__, "cannot malloc");
+    compData = malloc(compSize);
+    if (compData == NULL)
+        OSPanic("stage_loader.c", __LINE__, "cannot malloc");
+
+    if (file_read(&file, compData, compSize, 0) < 0)
+        OSPanic("stage_loader.c", __LINE__, "cannot Read");
+    if (file_close(&file) != 1)
+        OSPanic("stage_loader.c", __LINE__, "cannot Close");
+
+    lzs_decompress(compData, uncompData);
+    free(compData);
+
+    decodedStageLzPtr = uncompData;
+    if (uncompData == NULL)
+        OSPanic("stage_loader.c", __LINE__, "cannot open stcoli\n");
+    decodedStageLzPtr->animGroups = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->animGroups);
+
+    coll = decodedStageLzPtr->animGroups;
+    for (i = 0; i < decodedStageLzPtr->animGroupCount; i++, coll++)
+    {
+        if (coll->anim != NULL)
+            adjust_stage_anim_ptrs(&coll->anim, decodedStageLzPtr);
+        if (coll->modelNames != NULL)
+        {
+            char **namep;
+            coll->modelNames = OFFSET_TO_PTR(decodedStageLzPtr, coll->modelNames);
+            namep = coll->modelNames;
+            while (*namep != NULL)
+            {
+                *namep = OFFSET_TO_PTR(decodedStageLzPtr, *namep);
+                namep++;
+            }
+        }
+        if (coll->triangles != NULL)
+            coll->triangles = OFFSET_TO_PTR(decodedStageLzPtr, coll->triangles);
+        if (coll->gridCellTris != NULL)
+        {
+            int j;
+            s16 **r5;
+
+            coll->gridCellTris = OFFSET_TO_PTR(decodedStageLzPtr, coll->gridCellTris);
+            for (j = 0, r5 = coll->gridCellTris; j < coll->gridCellCountX * coll->gridCellCountZ;
+                 j++, r5++)
+            {
+                if (*r5 != NULL)
+                    *r5 = OFFSET_TO_PTR(decodedStageLzPtr, *r5);
+            }
+        }
+        if (coll->goals != NULL)
+            coll->goals = OFFSET_TO_PTR(decodedStageLzPtr, coll->goals);
+        if (coll->unk48 != NULL)
+            coll->unk48 = OFFSET_TO_PTR(decodedStageLzPtr, coll->unk48);
+        if (coll->bumpers != NULL)
+            coll->bumpers = OFFSET_TO_PTR(decodedStageLzPtr, coll->bumpers);
+        if (coll->jamabars != NULL)
+            coll->jamabars = OFFSET_TO_PTR(decodedStageLzPtr, coll->jamabars);
+        if (coll->bananas != NULL)
+            coll->bananas = OFFSET_TO_PTR(decodedStageLzPtr, coll->bananas);
+        if (coll->coliCones != NULL)
+            coll->coliCones = OFFSET_TO_PTR(decodedStageLzPtr, coll->coliCones);
+        if (coll->coliSpheres != NULL)
+            coll->coliSpheres = OFFSET_TO_PTR(decodedStageLzPtr, coll->coliSpheres);
+        if (coll->coliCylinders != NULL)
+            coll->coliCylinders = OFFSET_TO_PTR(decodedStageLzPtr, coll->coliCylinders);
+        if (coll->animGroupModels != NULL)
+        {
+            struct AnimGroupModel *animGroupModel;
+            int j;
+
+            coll->animGroupModels = OFFSET_TO_PTR(decodedStageLzPtr, coll->animGroupModels);
+            for (j = 0, animGroupModel = coll->animGroupModels; j < coll->animGroupModelCount; j++, animGroupModel++)
+                animGroupModel->name = OFFSET_TO_PTR(decodedStageLzPtr, animGroupModel->name);
+        }
+        if (coll->unk88 != NULL)
+            coll->unk88 = OFFSET_TO_PTR(decodedStageLzPtr, coll->unk88);
+        if (coll->unk90 != NULL)
+        {
+            struct DecodedStageLzPtr_child_child4 *r4;
+            int j;
+
+            coll->unk90 = OFFSET_TO_PTR(decodedStageLzPtr, coll->unk90);
+            for (j = 0, r4 = coll->unk90; j < coll->unk8C; j++, r4++)
+                r4->unk0 = OFFSET_TO_PTR(decodedStageLzPtr, r4->unk0);
+        }
+    }
+
+    if (decodedStageLzPtr->startPos != NULL)
+        decodedStageLzPtr->startPos = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->startPos);
+    if (decodedStageLzPtr->pFallOutY != NULL)
+        decodedStageLzPtr->pFallOutY = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->pFallOutY);
+    if (decodedStageLzPtr->goals != NULL)
+        decodedStageLzPtr->goals = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->goals);
+    if (decodedStageLzPtr->unk24 != NULL)
+        decodedStageLzPtr->unk24 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk24);
+    if (decodedStageLzPtr->bumpers != NULL)
+        decodedStageLzPtr->bumpers = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->bumpers);
+    if (decodedStageLzPtr->jamabars != NULL)
+        decodedStageLzPtr->jamabars = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->jamabars);
+    if (decodedStageLzPtr->bananas != NULL)
+        decodedStageLzPtr->bananas = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->bananas);
+    if (decodedStageLzPtr->coliCones != NULL)
+        decodedStageLzPtr->coliCones = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->coliCones);
+    if (decodedStageLzPtr->coliCylinders != NULL)
+        decodedStageLzPtr->coliCylinders = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->coliCylinders);
+    if (decodedStageLzPtr->animGroupModels != NULL)
+        decodedStageLzPtr->animGroupModels = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->animGroupModels);
+    if (decodedStageLzPtr->unk64 != NULL)
+        decodedStageLzPtr->unk64 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk64);
+    if (decodedStageLzPtr->mirrors != NULL)
+        decodedStageLzPtr->mirrors = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->mirrors);
+
+    if (decodedStageLzPtr->bgObjects != NULL)
+    {
+        struct StageBgObject *bgObj;
+
+        decodedStageLzPtr->bgObjects = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->bgObjects);
+        for (i = 0, bgObj = decodedStageLzPtr->bgObjects; i < decodedStageLzPtr->bgObjectCount;
+             i++, bgObj++)
+        {
+            u32 r3 = bgObj->flags;
+
+            if (r3 & (1 << 15))
+            {
+                bgObj->flags &= 0xF;
+                bgObj->flags |= (r3 >> 12) & 0xFFFF0;
+            }
+            bgObj->name = OFFSET_TO_PTR(decodedStageLzPtr, bgObj->name);
+            if (bgObj->anim != NULL)
+                func_800473C0(&bgObj->anim, decodedStageLzPtr);
+            if (bgObj->flipbooks != NULL)
+                adjust_stage_flipbook_anims_ptrs(&bgObj->flipbooks, decodedStageLzPtr);
+        }
+    }
+
+    if (decodedStageLzPtr->fgObjects != NULL)
+    {
+        struct StageBgObject *bgObj;
+
+        decodedStageLzPtr->fgObjects = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->fgObjects);
+        for (i = 0, bgObj = decodedStageLzPtr->fgObjects; i < decodedStageLzPtr->fgObjectCount; i++, bgObj++)
+        {
+            u32 r3 = bgObj->flags;
+
+            if (r3 & (1 << 15))
+            {
+                bgObj->flags = r3 & 0xF;
+                bgObj->flags |= (r3 >> 12) & 0xFFFF0;
+            }
+            bgObj->name = OFFSET_TO_PTR(decodedStageLzPtr, bgObj->name);
+            if (bgObj->anim != NULL)
+                func_800473C0(&bgObj->anim, decodedStageLzPtr);
+            if (bgObj->flipbooks != NULL)
+                adjust_stage_flipbook_anims_ptrs(&bgObj->flipbooks, decodedStageLzPtr);
+        }
+    }
+
+    if (decodedStageLzPtr->unk78 != NULL)
+    {
+        int j;
+        struct DecodedStageLzPtr_child5 *r3;
+        struct DecodedStageLzPtr_child5_child *r6;
+
+        r3 = decodedStageLzPtr->unk78 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk78);
+        if (r3->unk4 != NULL)
+            r3->unk4 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk4);
+        if (r3->unkC != NULL)
+            r3->unkC = OFFSET_TO_PTR(decodedStageLzPtr, r3->unkC);
+        if (r3->unk14 != NULL)
+            r3->unk14 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk14);
+        if (r3->unk1C != NULL)
+            r3->unk1C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk1C);
+        r6 = r3->unk1C;
+        for (j = 0; j < r3->unk18; j++, r6++)
+        {
+            if (r6->unk4 != NULL)
+                r6->unk4 = OFFSET_TO_PTR(decodedStageLzPtr, r6->unk4);
+            if (r6->unkC != NULL)
+                r6->unkC = OFFSET_TO_PTR(decodedStageLzPtr, r6->unkC);
+            if (r6->unk14 != NULL)
+                r6->unk14 = OFFSET_TO_PTR(decodedStageLzPtr, r6->unk14);
+        }
+        if (r3->unk24 != NULL)
+            r3->unk24 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk24);
+        if (r3->unk2C != NULL)
+            r3->unk2C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk2C);
+        if (r3->unk34 != NULL)
+            r3->unk34 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk34);
+        if (r3->unk3C != NULL)
+            r3->unk3C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk3C);
+        if (r3->unk44 != NULL)
+            r3->unk44 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk44);
+        if (r3->unk4C != NULL)
+            r3->unk4C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk4C);
+        if (r3->unk54 != NULL)
+            r3->unk54 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk54);
+        if (r3->unk5C != NULL)
+            r3->unk5C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk5C);
+        if (r3->unk64 != NULL)
+            r3->unk64 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk64);
+    }
+
+    if (decodedStageLzPtr->unk88 != NULL)
+    {
+        decodedStageLzPtr->unk88 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk88);
+        if (decodedStageLzPtr->unk88->unkC != NULL)
+            adjust_stage_anim_ptrs(&decodedStageLzPtr->unk88->unkC, decodedStageLzPtr);
+        if (decodedStageLzPtr->unk88->unk10 != NULL)
+            adjust_stage_anim_ptrs(&decodedStageLzPtr->unk88->unk10, decodedStageLzPtr);
+    }
+
+    if (decodedStageLzPtr->unk90 != NULL)
+        decodedStageLzPtr->unk90 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk90);
+    if (decodedStageLzPtr->unk7C < 1)
+        decodedStageLzPtr->unk7C = 1;
+}
+
+void free_stage_collision(void)
+{
+    if (decodedStageLzPtr != NULL)
+    {
+        free(decodedStageLzPtr);
+        decodedStageLzPtr = NULL;
+    }
+}

--- a/src/lib/stage_loader.c
+++ b/src/lib/stage_loader.c
@@ -1,9 +1,8 @@
 #include "dolphin.h"
 #include <stdio.h>
 #include <stddef.h>
-
-void *malloc(size_t);
-void free(void *);
+#include <stdlib.h>
+#include "ppcintrinsic.h"
 
 #include "global.h"
 #include "load.h"

--- a/src/lib/stage_loader.c
+++ b/src/lib/stage_loader.c
@@ -1,6 +1,9 @@
-#include <dolphin.h>
+#include "dolphin.h"
 #include <stdio.h>
-#include <stdlib.h>
+#include <stddef.h>
+
+void *malloc(size_t);
+void free(void *);
 
 #include "global.h"
 #include "load.h"

--- a/src/lzs_decompress.c
+++ b/src/lzs_decompress.c
@@ -1,4 +1,4 @@
-#include <dolphin.h>
+#include "dolphin.h"
 
 #include <ppcintrinsic.h>
 

--- a/src/stage.c
+++ b/src/stage.c
@@ -24,6 +24,7 @@
 #include "recplay.h"
 #include "shadow.h"
 #include "stage.h"
+#include "stage_loader.h"
 #include "stcoli.h"
 #include "window.h"
 
@@ -41,7 +42,6 @@ u16 lbl_802F1F40;
 struct TPL *decodedStageTplPtr;
 struct GMA *decodedStageGmaPtr;
 struct GMAModel *u_stageBoxModel;
-struct Stage *decodedStageLzPtr;
 struct GMAModel *blurBridgeAccordion;
 int previewLoaded;
 
@@ -519,7 +519,7 @@ void load_stage(int stageId)
             decodedStageGmaPtr = NULL;
         }
         nlObjModelListFree(&g_stageNlObj, &g_stageNlTpl);
-        free_stagedef();
+        free_stage_collision();
 
         OSSetCurrentHeap(oldHeap);
     }
@@ -574,7 +574,7 @@ void unload_stage(void)
             decodedStageGmaPtr = NULL;
         }
         nlObjModelListFree(&g_stageNlObj, &g_stageNlTpl);
-        free_stagedef();
+        free_stage_collision();
 
         OSSetCurrentHeap(oldHeap);
 
@@ -668,7 +668,7 @@ void load_stage_files(int stageId)
         oldHeap = OSSetCurrentHeap(stageHeap);
 
         // Load stagedef (.lz) file
-        load_stagedef(stageId);
+        load_stage_collision(stageId);
 
         // Load GMA/TPL files
         if (stageId != ST_190_DUMMY)
@@ -1653,272 +1653,6 @@ void u_some_stage_vtx_callback_2(Point3d *vtx) // duplicate of u_some_stage_vtx_
     lbl_8020ADE4.unk10 = mathutil_sqrt(f1);
 }
 
-u8 lbl_801B87FC[] = {1, 1, 1, 1, 1, 1, 3, 4, 4, 4, 1, 2, 7, 6, 5, 0};
-
-u8 lbl_8020AE00[0x20] __attribute__((aligned(32)));
-FORCE_BSS_ORDER(lbl_8020AE00)
-
-// parameters swapped?
-#undef OFFSET_TO_PTR
-#define OFFSET_TO_PTR(base, offset) (void *)((u32)(offset) + (u32)(base))
-
-void load_stagedef(int stageId)
-{
-    struct File file;
-    char filename[32];
-    u8 unused[8];
-    u32 compSize;
-    u32 uncompSize;
-    void *compData;
-    void *uncompData;
-    struct StageAnimGroup *coll;
-    int i;
-
-    sprintf(filename, "STAGE%03d.lz", stageId);
-
-    if (!file_open(filename, &file))
-        OSPanic("stage.c", 1960, "cannot Open");
-
-    // Read LZSS header
-    if (file_read(&file, lbl_8020AE00, 32, 0) < 0)
-        OSPanic("stage.c", 1962, "cannot Read");
-    compSize = OSRoundUp32B(__lwbrx(lbl_8020AE00, 0));
-    uncompSize = OSRoundUp32B(__lwbrx(lbl_8020AE00, 4));
-
-    // Allocate buffers
-    uncompData = OSAlloc(uncompSize);
-    if (uncompData == NULL)
-        OSPanic("stage.c", 1966, "cannot OSAlloc");
-    compData = OSAlloc(compSize);
-    if (compData == NULL)
-        OSPanic("stage.c", 1967, "cannot OSAlloc");
-
-    // Read whole file
-    if (file_read(&file, compData, compSize, 0) < 0)
-        OSPanic("stage.c", 1969, "cannot Read");
-    if (file_close(&file) != 1)
-        OSPanic("stage.c", 1970, "cannot Close");
-
-    // Decompress data
-    lzs_decompress(compData, uncompData);
-    OSFree(compData);
-
-    decodedStageLzPtr = uncompData;
-    if (uncompData == NULL)
-        OSPanic("stage.c", 1976, "cannot open stcoli\n");
-    decodedStageLzPtr->animGroups = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->animGroups);
-
-    coll = decodedStageLzPtr->animGroups;
-    for (i = 0; i < decodedStageLzPtr->animGroupCount; i++, coll++)
-    {
-        if (coll->anim != NULL)
-            adjust_stage_anim_ptrs(&coll->anim, decodedStageLzPtr);
-        if (coll->modelNames != NULL)
-        {
-            char **namep;
-            coll->modelNames = OFFSET_TO_PTR(decodedStageLzPtr, coll->modelNames);
-            namep = coll->modelNames;
-            while (*namep != NULL)
-            {
-                *namep = OFFSET_TO_PTR(decodedStageLzPtr, *namep);
-                namep++;
-            }
-        }
-        if (coll->triangles != NULL)
-            coll->triangles = OFFSET_TO_PTR(decodedStageLzPtr, coll->triangles);
-        if (coll->gridCellTris != NULL)
-        {
-            int j;
-            s16 **r5;
-
-            coll->gridCellTris = OFFSET_TO_PTR(decodedStageLzPtr, coll->gridCellTris);
-            for (j = 0, r5 = coll->gridCellTris; j < coll->gridCellCountX * coll->gridCellCountZ;
-                 j++, r5++)
-            {
-                if (*r5 != NULL)
-                    *r5 = OFFSET_TO_PTR(decodedStageLzPtr, *r5);
-            }
-        }
-        if (coll->goals != NULL)
-            coll->goals = OFFSET_TO_PTR(decodedStageLzPtr, coll->goals);
-        if (coll->unk48 != NULL)
-            coll->unk48 = OFFSET_TO_PTR(decodedStageLzPtr, coll->unk48);
-        if (coll->bumpers != NULL)
-            coll->bumpers = OFFSET_TO_PTR(decodedStageLzPtr, coll->bumpers);
-        if (coll->jamabars != NULL)
-            coll->jamabars = OFFSET_TO_PTR(decodedStageLzPtr, coll->jamabars);
-        if (coll->bananas != NULL)
-            coll->bananas = OFFSET_TO_PTR(decodedStageLzPtr, coll->bananas);
-        if (coll->coliCones != NULL)
-            coll->coliCones = OFFSET_TO_PTR(decodedStageLzPtr, coll->coliCones);
-        if (coll->coliSpheres != NULL)
-            coll->coliSpheres = OFFSET_TO_PTR(decodedStageLzPtr, coll->coliSpheres);
-        if (coll->coliCylinders != NULL)
-            coll->coliCylinders = OFFSET_TO_PTR(decodedStageLzPtr, coll->coliCylinders);
-        if (coll->animGroupModels != NULL)
-        {
-            struct AnimGroupModel *animGroupModel;
-            int j;
-
-            coll->animGroupModels = OFFSET_TO_PTR(decodedStageLzPtr, coll->animGroupModels);
-            for (j = 0, animGroupModel = coll->animGroupModels; j < coll->animGroupModelCount; j++, animGroupModel++)
-                animGroupModel->name = OFFSET_TO_PTR(decodedStageLzPtr, animGroupModel->name);
-        }
-        if (coll->unk88 != NULL)
-            coll->unk88 = OFFSET_TO_PTR(decodedStageLzPtr, coll->unk88);
-        if (coll->unk90 != NULL)
-        {
-            struct DecodedStageLzPtr_child_child4 *r4;
-            int j;
-
-            coll->unk90 = OFFSET_TO_PTR(decodedStageLzPtr, coll->unk90);
-            for (j = 0, r4 = coll->unk90; j < coll->unk8C; j++, r4++)
-                r4->unk0 = OFFSET_TO_PTR(decodedStageLzPtr, r4->unk0);
-        }
-    }
-
-    if (decodedStageLzPtr->startPos != NULL)
-        decodedStageLzPtr->startPos = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->startPos);
-    if (decodedStageLzPtr->pFallOutY != NULL)
-        decodedStageLzPtr->pFallOutY =
-            OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->pFallOutY);
-    if (decodedStageLzPtr->goals != NULL)
-        decodedStageLzPtr->goals = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->goals);
-    if (decodedStageLzPtr->unk24 != NULL)
-        decodedStageLzPtr->unk24 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk24);
-    if (decodedStageLzPtr->bumpers != NULL)
-        decodedStageLzPtr->bumpers = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->bumpers);
-    if (decodedStageLzPtr->jamabars != NULL)
-        decodedStageLzPtr->jamabars = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->jamabars);
-    if (decodedStageLzPtr->bananas != NULL)
-        decodedStageLzPtr->bananas = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->bananas);
-    if (decodedStageLzPtr->coliCones != NULL)
-        decodedStageLzPtr->coliCones =
-            OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->coliCones);
-    if (decodedStageLzPtr->coliCylinders != NULL)
-        decodedStageLzPtr->coliCylinders =
-            OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->coliCylinders);
-    if (decodedStageLzPtr->animGroupModels != NULL)
-        decodedStageLzPtr->animGroupModels =
-            OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->animGroupModels);
-    if (decodedStageLzPtr->unk64 != NULL)
-        decodedStageLzPtr->unk64 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk64);
-    if (decodedStageLzPtr->mirrors != NULL)
-        decodedStageLzPtr->mirrors = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->mirrors);
-
-    if (decodedStageLzPtr->bgObjects != NULL)
-    {
-        struct StageBgObject *bgObj;
-
-        decodedStageLzPtr->bgObjects = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->bgObjects);
-        for (i = 0, bgObj = decodedStageLzPtr->bgObjects; i < decodedStageLzPtr->bgObjectCount;
-             i++, bgObj++)
-        {
-            u32 r3 = bgObj->flags;
-
-            if (r3 & (1 << 15))
-            {
-                bgObj->flags &= 0xF;
-                bgObj->flags |= (r3 >> 12) & 0xFFFF0;
-            }
-            bgObj->name = OFFSET_TO_PTR(decodedStageLzPtr, bgObj->name);
-            if (bgObj->anim != NULL)
-                func_800473C0(&bgObj->anim, decodedStageLzPtr);
-            if (bgObj->flipbooks != NULL)
-                adjust_stage_flipbook_anims_ptrs(&bgObj->flipbooks, decodedStageLzPtr);
-        }
-    }
-
-    if (decodedStageLzPtr->fgObjects != NULL)
-    {
-        struct StageBgObject *bgObj;
-
-        decodedStageLzPtr->fgObjects = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->fgObjects);
-        for (i = 0, bgObj = decodedStageLzPtr->fgObjects; i < decodedStageLzPtr->fgObjectCount; i++, bgObj++)
-        {
-            u32 r3 = bgObj->flags;
-
-            if (r3 & (1 << 15))
-            {
-                bgObj->flags = r3 & 0xF;
-                bgObj->flags |= (r3 >> 12) & 0xFFFF0;
-            }
-            bgObj->name = OFFSET_TO_PTR(decodedStageLzPtr, bgObj->name);
-            if (bgObj->anim != NULL)
-                func_800473C0(&bgObj->anim, decodedStageLzPtr);
-            if (bgObj->flipbooks != NULL)
-                adjust_stage_flipbook_anims_ptrs(&bgObj->flipbooks, decodedStageLzPtr);
-        }
-    }
-
-    if (decodedStageLzPtr->unk78 != NULL)
-    {
-        int j;
-        struct DecodedStageLzPtr_child5 *r3;
-        struct DecodedStageLzPtr_child5_child *r6;
-
-        r3 = decodedStageLzPtr->unk78 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk78);
-        if (r3->unk4 != NULL)
-            r3->unk4 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk4);
-        if (r3->unkC != NULL)
-            r3->unkC = OFFSET_TO_PTR(decodedStageLzPtr, r3->unkC);
-        if (r3->unk14 != NULL)
-            r3->unk14 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk14);
-        if (r3->unk1C != NULL)
-            r3->unk1C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk1C);
-        r6 = r3->unk1C;
-        for (j = 0; j < r3->unk18; j++, r6++)
-        {
-            if (r6->unk4 != NULL)
-                r6->unk4 = OFFSET_TO_PTR(decodedStageLzPtr, r6->unk4);
-            if (r6->unkC != NULL)
-                r6->unkC = OFFSET_TO_PTR(decodedStageLzPtr, r6->unkC);
-            if (r6->unk14 != NULL)
-                r6->unk14 = OFFSET_TO_PTR(decodedStageLzPtr, r6->unk14);
-        }
-        if (r3->unk24 != NULL)
-            r3->unk24 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk24);
-        if (r3->unk2C != NULL)
-            r3->unk2C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk2C);
-        if (r3->unk34 != NULL)
-            r3->unk34 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk34);
-        if (r3->unk3C != NULL)
-            r3->unk3C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk3C);
-        if (r3->unk44 != NULL)
-            r3->unk44 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk44);
-        if (r3->unk4C != NULL)
-            r3->unk4C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk4C);
-        if (r3->unk54 != NULL)
-            r3->unk54 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk54);
-        if (r3->unk5C != NULL)
-            r3->unk5C = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk5C);
-        if (r3->unk64 != NULL)
-            r3->unk64 = OFFSET_TO_PTR(decodedStageLzPtr, r3->unk64);
-    }
-
-    if (decodedStageLzPtr->unk88 != NULL)
-    {
-        decodedStageLzPtr->unk88 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk88);
-        if (decodedStageLzPtr->unk88->unkC != NULL)
-            adjust_stage_anim_ptrs(&decodedStageLzPtr->unk88->unkC, decodedStageLzPtr);
-        if (decodedStageLzPtr->unk88->unk10 != NULL)
-            adjust_stage_anim_ptrs(&decodedStageLzPtr->unk88->unk10, decodedStageLzPtr);
-    }
-
-    if (decodedStageLzPtr->unk90 != NULL)
-        decodedStageLzPtr->unk90 = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->unk90);
-    if (decodedStageLzPtr->unk7C < 1)
-        decodedStageLzPtr->unk7C = 1;
-}
-
-void free_stagedef(void)
-{
-    if (decodedStageLzPtr != NULL)
-    {
-        OSFree(decodedStageLzPtr);
-        decodedStageLzPtr = NULL;
-    }
-}
 
 void adjust_stage_anim_ptrs(struct StageAnimGroupAnim **animp, struct Stage *baseptr)
 {

--- a/src/stage.h
+++ b/src/stage.h
@@ -604,8 +604,6 @@ int get_stage_background_2(int stageId);
 void compute_stage_bounding_sphere(void);
 void func_800463E8(Vec *, float *);
 float func_80046884(struct NlModel *);
-void load_stagedef(int stageId);
-void free_stagedef(void);
 void adjust_stage_anim_ptrs(struct StageAnimGroupAnim **, struct Stage *);
 void func_800473C0(struct StageBgAnim **, struct Stage *);
 void adjust_stage_flipbook_anims_ptrs(struct StageFlipbookAnims **, struct Stage *);


### PR DESCRIPTION
## Summary
- add basic ball and camera simulation wrappers for main game mode
- start factoring out stage collision loader
- compile new stage loader module using malloc/free

## Testing
- `make -s` *(fails: `/bin/powerpc-eabi-as: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6850f0a64310832d8fe88e291b917077