### PR TITLE
Update README with expanded libmkb details

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ supermonkeyball.dol: `sha1: 424e8ce10135686de0709a147e6a3a5a3fda02f1`
 
 ### Building libmkb
 
-Running `make libmkb.a` will compile the standalone simulation library `libmkb.a` using the host compiler. This library contains the stage loading, ball, and camera simulation code and can be linked into custom frontends.
+Running `make libmkb.a` will compile the standalone simulation library `libmkb.a` using the host compiler. This library contains the stage loading, ball, camera, world, stage object, item and animation simulation code and can be linked into custom frontends. The full list of available functions is documented in [include/libmkb.h](include/libmkb.h).
 
 Example usage:
 
@@ -39,16 +39,39 @@ int main(void) {
     struct Camera camera;
 
     load_stage_collision(1);       // Load STAGE001
+    world_sim_init();
+    stobj_sim_init();
+    item_sim_init();
+    stage_anim_init();
     ball_sim_init(&ball);
     camera_sim_init(&camera, &ball);
 
     while (1) {
+        world_sim_step();
+        stobj_sim_step();
+        item_sim_step();
+        stage_anim_step();
         ball_sim_step(&ball);
         camera_sim_step(&camera, &ball);
         // render here
     }
 
+    stage_anim_destroy();
+    item_sim_destroy();
+    stobj_sim_destroy();
+    world_sim_destroy();
     free_stage_collision();
     return 0;
 }
 ```
+
+### Building libmkb for WebAssembly
+
+The library can also be compiled with [Emscripten](https://emscripten.org/) to produce a WebAssembly build. Configure the project using `emcmake cmake` and then build the target:
+
+```bash
+emcmake cmake -B build .
+cmake --build build --target libmkb
+```
+
+Alternatively you can invoke `emcc` directly on the source files if you prefer a custom build system.


### PR DESCRIPTION
## Summary
- document new simulation entry points for libmkb
- extend the code example with new functions
- add instructions for building libmkb with Emscripten

## Testing
- `make libmkb.a`

------
https://chatgpt.com/codex/tasks/task_e_68510b4f6764832db8ad4f09b79fc52e