### PR TITLE
Fix LIBMKB host headers to use system types

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -1,14 +1,12 @@
-#ifndef _STDDEF_H_
-#define _STDDEF_H_
-
-#define offsetof(type, member)	((size_t) &(((type *) 0)->member))
+#ifndef LIBMKB_STDDEF_H
+#define LIBMKB_STDDEF_H
 
 #ifdef LIBMKB_HOST
-typedef unsigned long size_t;
+# include_next <stddef.h>
 #else
+# define offsetof(type, member)  ((size_t) &(((type *) 0)->member))
 typedef unsigned int size_t;
+# define NULL 0L
 #endif
-
-#define NULL 0L
 
 #endif

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -1,10 +1,12 @@
-#ifndef _WCHAR_H_
-#define _WCHAR_H_
+#ifndef LIBMKB_WCHAR_H
+#define LIBMKB_WCHAR_H
 
-#include <stdio.h>
-
+#ifdef LIBMKB_HOST
+# include <wchar.h>
+#else
+# include <stdio.h>
 typedef unsigned short wchar_t;
-
 int fwide(FILE *stream, int mode);
+#endif
 
 #endif


### PR DESCRIPTION
## Summary
- avoid redefining `size_t` and `wchar_t` when building the host version of libmkb
- include system `<stddef.h>` and `<wchar.h>` instead

## Testing
- `make HOSTCC=gcc libmkb.a`

------
https://chatgpt.com/codex/tasks/task_e_685113cd78d8832dadd0e773612d007e