### PR TITLE
Fix mismatched prototypes

### DIFF
--- a/src/avdisp.h
+++ b/src/avdisp.h
@@ -222,7 +222,7 @@ void avdisp_set_bound_sphere_scale(float);
 void avdisp_set_ambient(float, float, float);
 void avdisp_draw_model_culled_sort_translucent(struct GMAModel *);
 void avdisp_draw_model_culled_sort_none(struct GMAModel *);
-void avdisp_draw_model_culled_sort_all();
+void avdisp_draw_model_culled_sort_all(struct GMAModel *model);
 void avdisp_set_alpha(float alpha);
 void avdisp_set_light_mask(u32 lightMask);
 void avdisp_set_inf_light_dir(Vec *a);

--- a/src/background.h
+++ b/src/background.h
@@ -422,7 +422,7 @@ void bg_default_finish(void);
 void bg_default_draw(void);
 void bg_default_interact(int);
 void animate_bg_objects(struct StageBgObject *bgModels, int bgModelCount, float timeSeconds);
-void draw_bg_objects();
+void draw_bg_objects(Mtx viewFromWorld, struct StageBgObject *bgObj, int bgObjCount);
 void draw_bg_flipbooks(Mtx a, struct StageFlipbookAnims *b);
 void bg_night_init(void);
 void bg_night_main(void);

--- a/src/ball.h
+++ b/src/ball.h
@@ -186,7 +186,7 @@ void check_ball_teeter(struct Ape *a);
 // ? func_80037098();
 void u_choose_ape_anim(struct Ape *a, float b);
 void func_8003765C(struct Ape *a);
-void func_80037718();
+void func_80037718(struct Ape *unused);
 void func_80037B1C(struct Ball *);
 void ball_set_ape_flags_80037B20(void);
 void ev_ball_init(void);

--- a/src/functions.h
+++ b/src/functions.h
@@ -22,8 +22,8 @@ void u_menu_input_notdebug(void);
 void submode_dummy_func(void);
 
 void u_reset_gamedata(void);
-void u_store_gamedata();
-void u_load_gamedata();
+void u_store_gamedata(struct MemcardContents *data);
+void u_load_gamedata(struct MemcardContents *data);
 
 void mode_sel_func(void);
 void func_800123DC(void);
@@ -68,7 +68,7 @@ void u_mot_joint_start_anim(struct ApeAnimationThing *);
 void mot_joint_800355FC(struct ApeAnimationThing *);
 
 void u_update_skel_anim(struct ApeAnimationThing *);
-void u_joint_tree_calc_some_matrix();
+void u_joint_tree_calc_some_matrix(struct AnimJoint *jointArr, struct AnimJoint *joint);
 // ? u_joint_tree_calc_some_other_matrix();
 // ? calc_some_rotation_mtx_from_vec();
 // ? func_80035E7C();
@@ -88,7 +88,7 @@ void u_apply_func_to_nl_model_vertices(struct NlModel *model, void (*b)(struct N
 void u_apply_func_to_nl_disp_list_type_b(struct NlDispList *dl, void *end, void (*func)(struct NlVtxTypeB *));
 void u_apply_func_to_nl_disp_list_type_a(struct NlDispList *dl, void *end, void (*func)(struct NlVtxTypeA *));
 void func_80048084(struct NlModel *arg0, struct NlModel *arg1, float *arg2);
-void func_80048420();
+void func_80048420(struct NlModel *arg0, struct NlModel *arg1, float *arg2);
 
 // ? func_80081D34();
 // ? func_80081D64();

--- a/src/light.h
+++ b/src/light.h
@@ -100,7 +100,7 @@ extern char *s_lightIdNames[];
 extern char *s_lightGroupNames[];
 extern s8 lbl_802F1C6C[8];
 
-void light_init();
+void light_init(int stageId);
 void light_main();
 BOOL add_light_to_pool(struct Light *a);
 void load_light_group_uncached(int);

--- a/src/preview.h
+++ b/src/preview.h
@@ -26,7 +26,7 @@ void preview_create(struct Preview *preview, char *filename, int index, u32 widt
 void start_preview_image_read(struct Preview *preview, int index);
 void preview_sync(struct Preview *preview);
 void preview_main(struct Preview *preview);
-void preview_free();
+void preview_free(struct Preview *preview);
 void preview_draw(struct Preview *preview, u32 color0, u32 color1, float x, float y, float z, float width, float height);
 
 #endif

--- a/src/rend_efc.h
+++ b/src/rend_efc.h
@@ -34,7 +34,7 @@ struct RenderEffectFuncs
 void ev_rend_efc_init(void);
 void ev_rend_efc_main(void);
 void ev_rend_efc_dest(void);
-void rend_efc_draw();
+void rend_efc_draw(int enableFlags);
 void rend_efc_enable(int index, int type, struct RenderEffect *params);
 void rend_efc_blur_init(struct RenderEffect *);
 void rend_efc_blur_destroy(struct RenderEffect *);

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -317,7 +317,7 @@ void set_text_add_color(u32 color);
 void func_80071B1C(float);
 void set_text_scale(float scaleX, float scaleY);
 void set_text_opacity(float opacity);
-void func_80071B50();
+void func_80071B50(int flags);
 void set_text_pos(float x, float y);
 void sprite_putc(char chr);
 void sprite_puts(char *str);

--- a/src/stage.c
+++ b/src/stage.c
@@ -81,9 +81,9 @@ char *goalModelNames[] =
     "GOAL_R",
 };
 
-void u_bonus_wave_warp_callback_1();
-void u_bonus_wave_warp_callback_2();
-u32 bonus_wave_raycast_down();
+void u_bonus_wave_warp_callback_1(struct NlVtxTypeB *vtxp);
+void u_bonus_wave_warp_callback_2(struct NlVtxTypeA *vtxp);
+u32 bonus_wave_raycast_down(Point3d *rayOrigin, Point3d *outHitPos, Vec *outHitNormal);
 
 void ev_stage_init(void)
 {
@@ -1610,8 +1610,8 @@ struct
 } lbl_8020ADE4;
 FORCE_BSS_ORDER(lbl_8020ADE4)
 
-extern void u_some_stage_vtx_callback_1();
-extern void u_some_stage_vtx_callback_2();
+extern void u_some_stage_vtx_callback_1(Point3d *vtx);
+extern void u_some_stage_vtx_callback_2(Point3d *vtx);
 
 float func_80046884(struct NlModel *model)
 {

--- a/src/window.h
+++ b/src/window.h
@@ -64,7 +64,7 @@ void u_set_window_text(int, const char *);
 void u_clear_buffers_2_and_5(void);
 // ? clear_buffer_region();
 int window_printf_2(const char *, ...);
-void u_debug_print();
+void u_debug_print(char *str);
 int u_printf_if_debug(int, char *, ...);
 
 #endif


### PR DESCRIPTION
## Summary
- fix several function prototypes so the library can compile cleanly with strict checks

## Testing
- `make libmkb.a`

------
https://chatgpt.com/codex/tasks/task_e_68511cbed1b4832d8d67d7c80dd1c0e1