### PR TITLE
Fix host build sqrtf error

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -23,6 +23,14 @@ double copysign(double x, double y);
 
 double floor(double x);
 
+#ifdef LIBMKB_HOST
+double sqrt(double x);
+static inline double __frsqrte(double n)
+{
+    return 1.0 / sqrt(n);
+}
+#endif
+
 #ifdef __MWERKS__
 #pragma cplusplus on
 #endif


### PR DESCRIPTION
## Summary
- add a sqrt fallback for host builds so `__frsqrte` is defined
- compile libmkb successfully

## Testing
- `make libmkb -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6851209527c8832d9f57155b064fd313