### PR TITLE
Fix Module redeclaration in webdemo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "smb-decomp",
+  "version": "1.0.0",
+  "description": "This repo contains a WIP disassembly/decompilation of the program code of Super Monkey Ball NTSC-U version (GMBE8P).",
+  "main": "index.js",
+  "scripts": {
+    "test": "node tests/webdemo.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/webdemo.js
+++ b/tests/webdemo.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const vm = require('vm');
+
+// Minimal mocks for browser globals used in main.js
+const mockWindow = {
+  addEventListener: () => {},
+};
+
+const context = vm.createContext({
+  window: mockWindow,
+  document: {},
+  Module: {}
+});
+
+try {
+  const src = fs.readFileSync('webdemo/main.js', 'utf8');
+  vm.runInContext(src, context, { filename: 'main.js' });
+  console.log('main.js executed in test context.');
+} catch (err) {
+  console.error('Execution failed:', err);
+  process.exit(1);
+}

--- a/webdemo/main.js
+++ b/webdemo/main.js
@@ -1,7 +1,8 @@
 // Basic three.js scene that steps the libmkb simulation.
 // libmkb.js and libmkb.wasm must be built with Emscripten.
 
-let Module = Module || {};
+// Reuse the Module object created by Emscripten if available
+var Module = typeof Module !== 'undefined' ? Module : {};
 
 // Keep track of WASD key state for simple tilt control
 const keys = { w: false, a: false, s: false, d: false };


### PR DESCRIPTION
## Summary
- avoid redeclaring `Module` in `webdemo/main.js`
- add a simple node test for the web demo
- provide `package.json` to run the test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685129732428832d85c8c34407951e61