### PR TITLE
Fix webdemo initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The library can also be compiled with [Emscripten](https://emscripten.org/) to p
 ```bash
 emcmake cmake -B build .
 cmake --build build --target libmkb
-emcc build/libmkb.a -s EXPORT_ALL=1 -s MODULARIZE=1 -o libmkb.js
+emcc build/libmkb.a -s EXPORT_ALL=1 -s MODULARIZE=1 -o webdemo/libmkb.js
 ```
 
 Alternatively you can invoke `emcc` directly on the source files if you prefer a custom build system.
@@ -80,8 +80,10 @@ Alternatively you can invoke `emcc` directly on the source files if you prefer a
 ### Web Frontend Demo
 
 A simple three.js based demo is provided in the `webdemo` directory. After
-building `libmkb.js` and `libmkb.wasm` with Emscripten, you can serve the folder
-with any static file server:
+building `libmkb.js` and `libmkb.wasm` with Emscripten copy both files into the
+`webdemo` folder. The demo script will automatically instantiate the
+WebAssembly module when the page loads. You can then serve the directory with
+any static file server:
 
 ```bash
 cd webdemo

--- a/webdemo/main.js
+++ b/webdemo/main.js
@@ -76,7 +76,7 @@ function animate() {
   renderer.render(scene, camera);
 }
 
-Module.onRuntimeInitialized = async () => {
+async function onModuleLoaded() {
   lib = Module;
   ballPtr = lib._malloc(BALL_SIZE);
   cameraPtr = lib._malloc(CAMERA_SIZE);
@@ -95,4 +95,13 @@ Module.onRuntimeInitialized = async () => {
 
   initThree();
   animate();
-};
+}
+
+// When using Emscripten with MODULARIZE=1, libmkb.js exports a factory
+// function instead of a ready-to-use Module object. Detect that case and
+// instantiate the module so onModuleLoaded runs once the runtime is ready.
+if (typeof Module === 'function') {
+  Module().then(m => { Module = m; onModuleLoaded(); });
+} else {
+  Module.onRuntimeInitialized = onModuleLoaded;
+}


### PR DESCRIPTION
## Summary
- handle MODULARIZE builds in webdemo by instantiating the module if needed
- point README webdemo instructions at webdemo/libmkb.js and clarify usage

## Testing
- `node tests/webdemo.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512ac58154832d90dafed5a8728cbc