### PR TITLE
Fix webdemo malloc call and improve test

### DIFF
--- a/tests/webdemo.js
+++ b/tests/webdemo.js
@@ -2,19 +2,56 @@ const fs = require('fs');
 const vm = require('vm');
 
 // Minimal mocks for browser globals used in main.js
-const mockWindow = {
-  addEventListener: () => {},
+const mockWindow = { addEventListener: () => {} };
+const mockDocument = { body: { appendChild: () => {} } };
+
+const mockTHREE = {
+  Scene: function () { this.add = () => {}; },
+  DirectionalLight: function () { this.position = { set: () => {} }; },
+  SphereGeometry: function () {},
+  MeshStandardMaterial: function () {},
+  Mesh: function () { this.position = { set: () => {} }; },
+  PerspectiveCamera: function () { this.position = {}; },
+  WebGLRenderer: function () { this.setSize = () => {}; this.domElement = {}; this.render = () => {}; },
+};
+
+// Dummy WebAssembly Module with stubs used in onModuleLoaded/animate
+const mockModule = {
+  HEAP8: new Uint8Array(1024),
+  _controllerInfo: 0,
+  _malloc: () => 0,
+  FS_createDataFile: () => {},
+  getValue: () => 0,
+  _load_stage_collision: () => {},
+  _world_sim_init: () => {},
+  _stobj_sim_init: () => {},
+  _item_sim_init: () => {},
+  _stage_anim_init: () => {},
+  _ball_sim_init: () => {},
+  _camera_sim_init: () => {},
+  _world_sim_step: () => {},
+  _stobj_sim_step: () => {},
+  _item_sim_step: () => {},
+  _stage_anim_step: () => {},
+  _ball_sim_step: () => {},
+  _camera_sim_step: () => {},
 };
 
 const context = vm.createContext({
   window: mockWindow,
-  document: {},
-  Module: {}
+  document: mockDocument,
+  THREE: mockTHREE,
+  Module: mockModule,
+  fetch: async () => ({ arrayBuffer: async () => new ArrayBuffer(0) }),
+  requestAnimationFrame: () => {},
 });
 
 try {
   const src = fs.readFileSync('webdemo/main.js', 'utf8');
   vm.runInContext(src, context, { filename: 'main.js' });
+  if (typeof context.Module.onRuntimeInitialized === 'function') {
+    context.Module.onRuntimeInitialized();
+  }
   console.log('main.js executed in test context.');
 } catch (err) {
   console.error('Execution failed:', err);

--- a/webdemo/main.js
+++ b/webdemo/main.js
@@ -78,8 +78,13 @@ function animate() {
 
 async function onModuleLoaded() {
   lib = Module;
-  ballPtr = lib._malloc(BALL_SIZE);
-  cameraPtr = lib._malloc(CAMERA_SIZE);
+  const malloc = lib._malloc || (lib.cwrap && lib.cwrap('malloc', 'number', ['number']));
+  if (!malloc) {
+    console.error('malloc not available in Module');
+    return;
+  }
+  ballPtr = malloc(BALL_SIZE);
+  cameraPtr = malloc(CAMERA_SIZE);
 
   const resp = await fetch('STAGE002.lz');
   const buf = new Uint8Array(await resp.arrayBuffer());


### PR DESCRIPTION
## Summary
- gracefully handle the case where `_malloc` is not exported by the WebAssembly module
- expand test harness to invoke `onRuntimeInitialized` in a mocked environment so errors are caught

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512c1f43bc832dac1ea28da16a5878