### PR TITLE
Add Emscripten build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ int main(void) {
 
 ### Building libmkb for WebAssembly
 
-The library can also be compiled with [Emscripten](https://emscripten.org/) to produce a WebAssembly build. Configure the project using `emcmake cmake` and then build the target. Once the static library is created, link it with `emcc` to generate `libmkb.js` and `libmkb.wasm`:
+The library can also be compiled with [Emscripten](https://emscripten.org/) to produce a WebAssembly build suitable for the browser. A helper script is provided to build the WebAssembly version and export all functions used by the simulation:
 
 ```bash
-emcmake cmake -B build .
-cmake --build build --target libmkb
-emcc build/libmkb.a -s EXPORT_ALL=1 -s MODULARIZE=1 -o webdemo/libmkb.js
+tools/build_wasm.sh
 ```
+
+This script configures the project with `emcmake`, builds the static library and then links it with `emcc`, exporting all of the simulation entry points and placing `libmkb.js` and `libmkb.wasm` in the `webdemo` directory.
 
 Alternatively you can invoke `emcc` directly on the source files if you prefer a custom build system.
 

--- a/tools/build_wasm.sh
+++ b/tools/build_wasm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Build libmkb with Emscripten and export all functions required by the
+# simulation. The resulting libmkb.js and libmkb.wasm are placed in the
+# webdemo directory.
+
+BUILD_DIR=build-wasm
+
+emcmake cmake -B "$BUILD_DIR" .
+cmake --build "$BUILD_DIR" --target libmkb
+
+emcc "$BUILD_DIR/libmkb.a" \
+  -s MODULARIZE=1 \
+  -s EXPORT_NAME=createMKBModule \
+  -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
+  -s EXPORTED_FUNCTIONS="['_load_stage_collision','_free_stage_collision','_ball_sim_init','_ball_sim_step','_camera_sim_init','_camera_sim_step','_world_sim_init','_world_sim_step','_world_sim_destroy','_stobj_sim_init','_stobj_sim_step','_stobj_sim_destroy','_item_sim_init','_item_sim_step','_item_sim_destroy','_stage_anim_init','_stage_anim_step','_stage_anim_destroy','_malloc']" \
+  -s EXPORTED_RUNTIME_METHODS="['cwrap','getValue','FS_createDataFile']" \
+  -o webdemo/libmkb.js


### PR DESCRIPTION
## Summary
- document building the WebAssembly version via `tools/build_wasm.sh`
- add a helper script that builds `libmkb.js` with the needed exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512e1fae7c832da5bf8b4b15830cea