### PR TITLE
Fix wasm build by adding stubs and extra sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,19 @@ set(LIBMKB_SOURCES
     src/item_coin.c
     src/obj_collision.c
     src/lzs_decompress.c
+    src/ball.c
+    src/camera.c
+    src/event.c
+    src/info.c
+    src/recplay.c
+    src/recplay_cmpr.c
+    src/adv.c
+    src/window.c
+    src/effect.c
+    src/sound.c
     src/lib/host_load.c
     src/lib/host_os.c
+    src/lib/globals.c
 )
 
 add_library(libmkb STATIC ${LIBMKB_SOURCES})

--- a/Makefile
+++ b/Makefile
@@ -587,7 +587,9 @@ LIBMKB_SRCS := src/lib/stage_loader.c src/lib/ball_sim.c src/lib/camera_sim.c \
                src/world.c src/stage.c src/stobj.c src/stobj_goal.c \
                src/item.c src/item_coin.c src/obj_collision.c \
                src/lzs_decompress.c \
-               src/lib/host_load.c src/lib/host_os.c
+               src/ball.c src/camera.c src/event.c src/info.c src/recplay.c \
+               src/recplay_cmpr.c src/adv.c src/window.c src/effect.c src/sound.c \
+               src/lib/host_load.c src/lib/host_os.c src/lib/globals.c
 LIBMKB_OBJS := $(LIBMKB_SRCS:.c=.lib.o)
 
 libmkb.a: $(LIBMKB_OBJS)

--- a/src/ball.c
+++ b/src/ball.c
@@ -428,7 +428,7 @@ void func_8003765C(struct Ape *ape)
 // needed here due to float constant ordering
 static float get_0_05(void) {return 0.05f;}
 
-void func_80037718(/* struct Ape *unused */)
+void func_80037718(struct Ape *unused)
 {
     Quaternion sp30;
     Vec sp24;

--- a/src/lib/globals.c
+++ b/src/lib/globals.c
@@ -1,0 +1,36 @@
+#include "mode.h"
+#include "window.h"
+#include "info.h"
+#include "recplay.h"
+#include "ball.h"
+#include "camera.h"
+#include "adv.h"
+#include "variables.h"
+
+// Stub global state for WebAssembly build
+struct ModeControl modeCtrl = {0};
+s16 gameMode = 0;
+s16 gameModeRequest = 0;
+s16 gameSubmode = 0;
+s16 gameSubmodeRequest = 0;
+void *modeStringPtr = NULL;
+void *submodeStringPtr = NULL;
+void (*lbl_802F1B70)(void) = NULL;
+void (*lbl_802F1B74)(void) = NULL;
+s32 lbl_802F1B78 = 0;
+
+u32 debugFlags = 0;
+
+struct Struct801F3A58 infoWork = {0};
+
+struct ReplayInfo g_recplayInfo = { {0}, 0.0f, 0 };
+
+struct Ball ballInfo[8] = {0};
+struct Ball *currentBall = NULL;
+
+struct Camera cameraInfo[5] = {0};
+struct Camera *currentCamera = NULL;
+
+struct AdvDemoInfo advDemoInfo = {0};
+
+struct GMA *commonGma = NULL;


### PR DESCRIPTION
## Summary
- add missing sources to CMakeLists and Makefile for building with emscripten
- provide stub global variables for web build in `globals.c`
- fix `func_80037718` prototype so it compiles with gcc/clang

## Testing
- `tools/build_wasm.sh` *(fails: emcmake: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685131f08168832daa344d86dfee9aff