### PR TITLE
Fix missing sndActive prototype

### DIFF
--- a/include/musyx/musyx.h
+++ b/include/musyx/musyx.h
@@ -157,7 +157,7 @@ typedef void (*SND_AUX_CALLBACK)(u8 reason, SND_AUX_INFO *info, void *user);
 void sndAuxCallbackChorus(u8 reason, SND_AUX_INFO *info, void *user);
 void sndAuxCallbackPrepareChorus();
 void sndOutputMode();
-//void sndActive();  // hmm
+int sndActive(u8 arg0, u8 arg1, u8 arg2, int arg3, u32 arg4);
 int sndPushGroup();
 void sndPopGroup(void);
 SND_VOICEID sndFXCheck(SND_VOICEID arg0);


### PR DESCRIPTION
## Summary
- expose sndActive in musyx.h for use by the main project

## Testing
- `make -j$(nproc)` *(fails: `/bin/powerpc-eabi-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68513549acf8832dbef2e38a1e7bbd37