### PR TITLE
Support stagedef files

### DIFF
--- a/src/lib/stage_loader.c
+++ b/src/lib/stage_loader.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 #include "ppcintrinsic.h"
 
 #include "global.h"
@@ -20,39 +21,54 @@ struct Stage *decodedStageLzPtr;
 void load_stage_collision_file(const char *path)
 {
     struct File file;
-    u8 unused[8];
-    u32 compSize;
-    u32 uncompSize;
-    void *compData;
-    void *uncompData;
     struct StageAnimGroup *coll;
     int i;
+    void *data;
+    u32 size;
 
     if (!file_open(path, &file))
         OSPanic("stage_loader.c", __LINE__, "cannot Open");
 
-    if (file_read(&file, lbl_8020AE00, 32, 0) < 0)
-        OSPanic("stage_loader.c", __LINE__, "cannot Read");
-    compSize = OSRoundUp32B(__lwbrx(lbl_8020AE00, 0));
-    uncompSize = OSRoundUp32B(__lwbrx(lbl_8020AE00, 4));
+    if (strlen(path) >= 9 && strcmp(path + strlen(path) - 9, ".stagedef") == 0)
+    {
+        size = OSRoundUp32B(file_size(&file));
+        data = malloc(size);
+        if (data == NULL)
+            OSPanic("stage_loader.c", __LINE__, "cannot malloc");
+        if (file_read(&file, data, size, 0) < 0)
+            OSPanic("stage_loader.c", __LINE__, "cannot Read");
+        if (file_close(&file) != 1)
+            OSPanic("stage_loader.c", __LINE__, "cannot Close");
+    }
+    else
+    {
+        u32 compSize;
+        u32 uncompSize;
+        void *compData;
 
-    uncompData = malloc(uncompSize);
-    if (uncompData == NULL)
-        OSPanic("stage_loader.c", __LINE__, "cannot malloc");
-    compData = malloc(compSize);
-    if (compData == NULL)
-        OSPanic("stage_loader.c", __LINE__, "cannot malloc");
+        if (file_read(&file, lbl_8020AE00, 32, 0) < 0)
+            OSPanic("stage_loader.c", __LINE__, "cannot Read");
+        compSize = OSRoundUp32B(__lwbrx(lbl_8020AE00, 0));
+        uncompSize = OSRoundUp32B(__lwbrx(lbl_8020AE00, 4));
 
-    if (file_read(&file, compData, compSize, 0) < 0)
-        OSPanic("stage_loader.c", __LINE__, "cannot Read");
-    if (file_close(&file) != 1)
-        OSPanic("stage_loader.c", __LINE__, "cannot Close");
+        data = malloc(uncompSize);
+        if (data == NULL)
+            OSPanic("stage_loader.c", __LINE__, "cannot malloc");
+        compData = malloc(compSize);
+        if (compData == NULL)
+            OSPanic("stage_loader.c", __LINE__, "cannot malloc");
 
-    lzs_decompress(compData, uncompData);
-    free(compData);
+        if (file_read(&file, compData, compSize, 0) < 0)
+            OSPanic("stage_loader.c", __LINE__, "cannot Read");
+        if (file_close(&file) != 1)
+            OSPanic("stage_loader.c", __LINE__, "cannot Close");
 
-    decodedStageLzPtr = uncompData;
-    if (uncompData == NULL)
+        lzs_decompress(compData, data);
+        free(compData);
+    }
+
+    decodedStageLzPtr = data;
+    if (data == NULL)
         OSPanic("stage_loader.c", __LINE__, "cannot open stcoli\n");
     decodedStageLzPtr->animGroups = OFFSET_TO_PTR(decodedStageLzPtr, decodedStageLzPtr->animGroups);
 
@@ -258,7 +274,7 @@ void load_stage_collision_file(const char *path)
 void load_stage_collision(int stageId)
 {
     char filename[32];
-    sprintf(filename, "STAGE%03d.lz", stageId);
+    sprintf(filename, "STAGE%03d.stagedef", stageId);
     load_stage_collision_file(filename);
 }
 

--- a/src/stage.c
+++ b/src/stage.c
@@ -667,7 +667,7 @@ void load_stage_files(int stageId)
         DVDChangeDir(stageDir);
         oldHeap = OSSetCurrentHeap(stageHeap);
 
-        // Load stagedef (.lz) file
+        // Load stagedef file
         load_stage_collision(stageId);
 
         // Load GMA/TPL files

--- a/tests/webdemo_sim.js
+++ b/tests/webdemo_sim.js
@@ -5,7 +5,11 @@ const path = require('path');
   const createMKBModule = require('../webdemo/libmkb.js');
   let Module;
   try {
-    Module = await createMKBModule();
+    // Node's fetch does not handle file:// URLs reliably; disable streaming
+    global.fetch = undefined;
+    Module = await createMKBModule({
+      locateFile: (file) => path.resolve(__dirname, '../webdemo', file)
+    });
   } catch (err) {
     console.error('Failed to initialise WebAssembly module:', err.message);
     process.exit(1);
@@ -18,16 +22,8 @@ const path = require('path');
 
   // Load stage data if available
   try {
-    const buf = fs.readFileSync(path.join(__dirname, '../webdemo/STAGE002.lz'));
-    // The WebAssembly build expects big-endian header values. The stage file
-    // shipped with the repo stores them in little-endian, so swap the first two
-    // 32-bit words before passing it to the module.
-    const swapped = Buffer.from(buf);
-    const srcSize = buf.readUInt32LE(0);
-    const dstSize = buf.readUInt32LE(4);
-    swapped.writeUInt32BE(srcSize, 0);
-    swapped.writeUInt32BE(dstSize, 4);
-    Module.FS_createDataFile('/', 'STAGE002.lz', swapped, true, true);
+    const buf = fs.readFileSync(path.join(__dirname, '../webdemo/STAGE002.stagedef'));
+    Module.FS_createDataFile('/', 'STAGE002.stagedef', buf, true, true);
     Module._load_stage_collision(2);
   } catch (err) {
     console.error('Failed to load stage data:', err.message);

--- a/webdemo/main.js
+++ b/webdemo/main.js
@@ -86,9 +86,9 @@ async function onModuleLoaded() {
   ballPtr = malloc(BALL_SIZE);
   cameraPtr = malloc(CAMERA_SIZE);
 
-  const resp = await fetch('STAGE002.lz');
+  const resp = await fetch('STAGE002.stagedef');
   const buf = new Uint8Array(await resp.arrayBuffer());
-  lib.FS_createDataFile('/', 'STAGE002.lz', buf, true, true);
+  lib.FS_createDataFile('/', 'STAGE002.stagedef', buf, true, true);
 
   lib._load_stage_collision(2);
   lib._world_sim_init();


### PR DESCRIPTION
## Summary
- support loading `.stagedef` files directly in the stage loader
- fetch the stagedef in the web demo
- update stage init comment
- adjust test harness to locate the wasm module and load the stagedef

## Testing
- `npm test` *(fails: PANIC cannot Open)*

------
https://chatgpt.com/codex/tasks/task_e_6851dae05cbc832daf21db0d46341b4f